### PR TITLE
fix UsageScenarioSwitch structure, adding 2 delegates and 1 DI

### DIFF
--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/DoSwitchInterface.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/DoSwitchInterface.java
@@ -1,0 +1,7 @@
+package org.palladiosimulator.simulizar.interpreter;
+
+import org.eclipse.emf.ecore.EObject;
+
+public interface DoSwitchInterface<T> {
+  public T doSwitch(EObject theEObject);
+}

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/UsageScenarioSwitchDeltaDelegate.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/UsageScenarioSwitchDeltaDelegate.java
@@ -1,0 +1,73 @@
+package org.palladiosimulator.simulizar.interpreter;
+
+import org.palladiosimulator.pcm.usagemodel.UsageScenario;
+import org.palladiosimulator.pcm.usagemodel.EntryLevelSystemCall;
+import org.palladiosimulator.simulizar.utils.SimulatedStackHelper;
+import org.palladiosimulator.simulizar.interpreter.listener.ModelElementPassedEvent;
+import org.palladiosimulator.simulizar.interpreter.listener.EventType;
+import de.uka.ipd.sdq.simucomframework.variables.StackContext;
+import org.palladiosimulator.simulizar.exceptions.PCMModelInterpreterException;
+import org.palladiosimulator.pcm.repository.OperationSignature;
+
+public class UsageScenarioSwitchDeltaDelegate {
+
+        private final InterpreterDefaultContext context;
+        private final DoSwitchInterface doSwitch;
+
+
+    public UsageScenarioSwitchDeltaDelegate(InterpreterDefaultContext context, DoSwitchInterface doSwitch){
+        this.context = context;
+        this.doSwitch = doSwitch;
+    }
+      /**
+     * @see org.palladiosimulator.pcm.usagemodel.util.UsagemodelSwitch#caseEntryLevelSystemCall(org.palladiosimulator.pcm.usagemodel.EntryLevelSystemCall)
+     */
+    public void caseEntryLevelSystemCall(final EntryLevelSystemCall entryLevelSystemCall) {
+        final RepositoryComponentSwitch providedDelegationSwitch = new RepositoryComponentSwitch(this.context,
+                RepositoryComponentSwitch.SYSTEM_ASSEMBLY_CONTEXT,
+                entryLevelSystemCall.getOperationSignature__EntryLevelSystemCall(),
+                entryLevelSystemCall.getProvidedRole_EntryLevelSystemCall());
+
+        this.context.getRuntimeState().getEventNotificationHelper()
+                .firePassedEvent(new ModelElementPassedEvent<EntryLevelSystemCall>(entryLevelSystemCall,
+                        EventType.BEGIN, this.context));
+
+        // FIXME We stick to single model elements here even though several would be needed to
+        // uniquely identify the measuring point of interest (system + role + signature) [Lehrig]
+        this.context.getRuntimeState().getEventNotificationHelper()
+                .firePassedEvent(new ModelElementPassedEvent<OperationSignature>(
+                        entryLevelSystemCall.getOperationSignature__EntryLevelSystemCall(), EventType.BEGIN,
+                        this.context));
+
+        // create new stack frame for input parameter
+        SimulatedStackHelper.createAndPushNewStackFrame(this.context.getStack(),
+                entryLevelSystemCall.getInputParameterUsages_EntryLevelSystemCall());
+        providedDelegationSwitch.doSwitch(entryLevelSystemCall.getProvidedRole_EntryLevelSystemCall());
+        this.context.getStack().removeStackFrame();
+
+        this.context.getRuntimeState().getEventNotificationHelper()
+                .firePassedEvent(new ModelElementPassedEvent<EntryLevelSystemCall>(entryLevelSystemCall, EventType.END,
+                        this.context));
+
+        // FIXME We stick to single model elements here even though several would be needed to
+        // uniquely identify the measuring point of interest (system + role + signature) [Lehrig]
+        this.context.getRuntimeState().getEventNotificationHelper()
+                .firePassedEvent(new ModelElementPassedEvent<OperationSignature>(
+                        entryLevelSystemCall.getOperationSignature__EntryLevelSystemCall(), EventType.END,
+                        this.context));
+    }
+        /**
+     * @see org.palladiosimulator.pcm.usagemodel.util.UsagemodelSwitch#caseUsageScenario(org.palladiosimulator.pcm.usagemodel.UsageScenario)
+     */
+    public void caseUsageScenario(final UsageScenario usageScenario) {
+        this.context.getRuntimeState().getEventNotificationHelper().firePassedEvent(
+                new ModelElementPassedEvent<UsageScenario>(usageScenario, EventType.BEGIN, this.context));
+        final int stacksize = this.context.getStack().size();
+        doSwitch.doSwitch(usageScenario.getScenarioBehaviour_UsageScenario());
+        if (this.context.getStack().size() != stacksize) {
+            throw new PCMModelInterpreterException("Interpreter did not pop all pushed stackframes");
+        }
+        this.context.getRuntimeState().getEventNotificationHelper().firePassedEvent(
+                new ModelElementPassedEvent<UsageScenario>(usageScenario, EventType.END, this.context));
+      }
+}

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/UsageScenarioSwitchPIDelegate.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/UsageScenarioSwitchPIDelegate.java
@@ -1,0 +1,100 @@
+package org.palladiosimulator.simulizar.interpreter;
+
+import de.uka.ipd.sdq.simucomframework.variables.StackContext;
+import org.apache.log4j.Logger;
+import org.palladiosimulator.pcm.usagemodel.AbstractUserAction;
+import org.palladiosimulator.pcm.usagemodel.Branch;
+import org.palladiosimulator.pcm.usagemodel.BranchTransition;
+import org.palladiosimulator.pcm.usagemodel.Delay;
+import org.palladiosimulator.pcm.usagemodel.EntryLevelSystemCall;
+import org.palladiosimulator.pcm.usagemodel.Loop;
+import org.palladiosimulator.pcm.usagemodel.ScenarioBehaviour;
+import org.palladiosimulator.pcm.usagemodel.Start;
+import org.palladiosimulator.pcm.usagemodel.UsageScenario;
+import org.palladiosimulator.simulizar.utils.TransitionDeterminer;
+
+
+public class UsageScenarioSwitchPIDelegate {
+    private final InterpreterDefaultContext context;
+    private final Logger LOGGER;
+    private final TransitionDeterminer transitionDeterminer;
+    private final DoSwitchInterface doSwitch;
+
+    public UsageScenarioSwitchPIDelegate(InterpreterDefaultContext context, Logger logger, DoSwitchInterface doSwitch){
+      this.context = context;
+      this.LOGGER = logger;
+      this.transitionDeterminer = new TransitionDeterminer(context);
+      this.doSwitch = doSwitch;
+    }
+
+    /**
+     * @see org.palladiosimulator.pcm.usagemodel.util.UsagemodelSwitch#caseBranch(org.palladiosimulator.pcm.usagemodel.Branch)
+     */
+    public void caseBranch(final Branch object) {
+        // determine branch transition
+        final BranchTransition branchTransition = this.transitionDeterminer
+                .determineBranchTransition(object.getBranchTransitions_Branch());
+
+        // interpret scenario behaviour of branch transition
+        doSwitch.doSwitch(branchTransition.getBranchedBehaviour_BranchTransition());
+    }
+
+    /**
+     * @see org.palladiosimulator.pcm.usagemodel.util.UsagemodelSwitch#caseDelay(org.palladiosimulator.pcm.usagemodel.Delay)
+     */
+    public void caseDelay(final Delay object) {
+        // determine delay
+        final double delay = StackContext.evaluateStatic(object.getTimeSpecification_Delay().getSpecification(),
+                Double.class);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Start delay " + delay + " @ simulation time "
+                    + this.context.getModel().getSimulationControl().getCurrentSimulationTime());
+        }
+        // hold simulation process
+        this.context.getThread().hold(delay);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Continue user @ simulation time "
+                    + this.context.getModel().getSimulationControl().getCurrentSimulationTime());
+        }
+    }
+        /**
+     * @see org.palladiosimulator.pcm.usagemodel.util.UsagemodelSwitch#caseLoop(org.palladiosimulator.pcm.usagemodel.Loop)
+     */
+    public void caseLoop(final Loop object) {
+        // determine number of loops
+        final int numberOfLoops = StackContext.evaluateStatic(object.getLoopIteration_Loop().getSpecification(),
+                Integer.class);
+        for (int i = 0; i < numberOfLoops; i++) {
+            LOGGER.debug("Interpret loop number " + i);
+            doSwitch.doSwitch(object.getBodyBehaviour_Loop());
+            LOGGER.debug("Finished loop number " + i);
+        }
+    }
+        /**
+     * @see org.palladiosimulator.pcm.usagemodel.util.UsagemodelSwitch#caseScenarioBehaviour(org.palladiosimulator.pcm.usagemodel.ScenarioBehaviour)
+     */
+    public void caseScenarioBehaviour(final ScenarioBehaviour object) {
+        // interpret start user action
+        for (final AbstractUserAction abstractUserAction : object.getActions_ScenarioBehaviour()) {
+            if (abstractUserAction instanceof Start) {
+                doSwitch.doSwitch(abstractUserAction);
+                break;
+            }
+        }
+    }
+        /**
+     * @see org.palladiosimulator.pcm.usagemodel.util.UsagemodelSwitch#caseAbstractUserAction(org.palladiosimulator.pcm.usagemodel.AbstractUserAction)
+     */
+    public void caseAbstractUserAction(final AbstractUserAction object) {
+        if (object.getSuccessor() != null) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Interpret " + object.getSuccessor().eClass().getName() + ": " + object);
+            }
+            doSwitch.doSwitch(object.getSuccessor());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Finished Interpretation of " + object.getSuccessor().eClass().getName() + ": " + object);
+            }
+        }
+    }
+    
+}

--- a/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/UsageScenarioSwitchPIDelegate.java
+++ b/bundles/org.palladiosimulator.simulizar/src/org/palladiosimulator/simulizar/interpreter/UsageScenarioSwitchPIDelegate.java
@@ -6,11 +6,9 @@ import org.palladiosimulator.pcm.usagemodel.AbstractUserAction;
 import org.palladiosimulator.pcm.usagemodel.Branch;
 import org.palladiosimulator.pcm.usagemodel.BranchTransition;
 import org.palladiosimulator.pcm.usagemodel.Delay;
-import org.palladiosimulator.pcm.usagemodel.EntryLevelSystemCall;
 import org.palladiosimulator.pcm.usagemodel.Loop;
 import org.palladiosimulator.pcm.usagemodel.ScenarioBehaviour;
 import org.palladiosimulator.pcm.usagemodel.Start;
-import org.palladiosimulator.pcm.usagemodel.UsageScenario;
 import org.palladiosimulator.simulizar.utils.TransitionDeterminer;
 
 


### PR DESCRIPTION
Ich hab für die PRs ein fork angelegt. Dies ist leider weil Github public, wenn das stört lösch ich es.
Ich habe bei UsageScenarioSwitch ´mal angefangen und es in 2 Klassen und ein Interface aufgeteilt.
Die 2 Klassen sind delegates und trennen PI/Delta, das Interface dient dazu den doSwitch(object:EObject) aufruf in den Delegates machen zu können ohne zyklische Abhängigkeit. Die Klassenbenennung ist erstmal vorläufig, dafür überleg ich mir noch ein einheitliches vorgehen und Formatierung/Checkstyle fehlt noch. 
## Vorher
![diagrammOLD](https://user-images.githubusercontent.com/25300639/86979442-a451fd00-c181-11ea-9284-e44fa49d639f.png)


## Nachher 
![diagrammFixed](https://user-images.githubusercontent.com/25300639/86979436-9ef4b280-c181-11ea-962f-1efed178ff04.png)



